### PR TITLE
Add options to relax path start and end constraints

### DIFF
--- a/include/netlist_paths/Graph.hpp
+++ b/include/netlist_paths/Graph.hpp
@@ -73,8 +73,11 @@ using FilteredInternalGraph = boost::filtered_graph<InternalGraph,
 class Graph {
 private:
   InternalGraph graph;
+  std::map<std::string, VertexID> aliasMap;
 
   bool vertexTypeMatch(VertexID vertex, VertexNetlistType graphType) const;
+
+  bool isAliasPath(const VertexIDVec &waypointIDs) const;
 
   VertexIDVec getAdjacentVerticesOutEdges(VertexID vertex) const;
 

--- a/include/netlist_paths/Graph.hpp
+++ b/include/netlist_paths/Graph.hpp
@@ -76,7 +76,9 @@ private:
 
   bool vertexTypeMatch(VertexID vertex, VertexNetlistType graphType) const;
 
-  VertexIDVec getAdjacentVertices(VertexID vertex) const;
+  VertexIDVec getAdjacentVerticesOutEdges(VertexID vertex) const;
+
+  VertexIDVec getAdjacentVerticesInEdges(VertexID vertex) const;
 
   VertexIDVec determinePath(ParentMap &parentMap,
                             VertexIDVec path,
@@ -136,6 +138,9 @@ public:
 
   /// Split register vertices into source and destination parts.
   void splitRegVertices();
+
+  /// Add additional edges to variable aliases.
+  void updateVarAliases();
 
   /// Perform some checks on the final graph.
   void checkGraph() const;

--- a/include/netlist_paths/Options.hpp
+++ b/include/netlist_paths/Options.hpp
@@ -25,6 +25,8 @@ class Options {
   bool ignoreHierarchyMarkers;
   bool matchOneVertex;
   bool traverseRegisters;
+  bool restrictStartPoints;
+  bool restrictEndPoints;
 
 public:
   bool isMatchExact() const { return matchType == MatchType::EXACT; }
@@ -34,6 +36,8 @@ public:
   bool isMatchAnyVertex() const { return !matchOneVertex; }
   bool shouldIgnoreHierarchyMarkers() const { return ignoreHierarchyMarkers; }
   bool shouldTraverseRegisters() const { return traverseRegisters; }
+  bool isRestrictStartPoints() const { return restrictStartPoints; }
+  bool isRestrictEndPoints() const { return restrictEndPoints; }
   bool isVerboseMode() const { return verboseMode; }
   bool isDebugMode() const { return debugMode; }
 
@@ -46,13 +50,10 @@ public:
   /// Set matching to be exact.
   void setMatchExact() { matchType = MatchType::EXACT; }
 
-  /// Set matching to ignore hierarchy markers (only with wildcard or regular
-  /// expression matching modes). Hierarchy markers are '.', '/' and '_'.
-  void setIgnoreHierarchyMarkers() { ignoreHierarchyMarkers = true; }
-
-  /// Set matching to respect hierarchy markers (ie not to ignore them, only
-  /// with wildcard or regular expression matching modes).
-  void setRespectHierarchyMarkers() { ignoreHierarchyMarkers = false; }
+  /// Set matching to ignore (true) or respect (false) hierarchy markers (only
+  /// with wildcard or regular expression matching modes). Note that hierarchy
+  /// markers are '.', '/' and '_'.
+  void setIgnoreHierarchyMarkers(bool value) { ignoreHierarchyMarkers = value; }
 
   /// Set matching to identify one vertex, and for it to be an error if more
   /// than one vertex is matched.
@@ -62,11 +63,18 @@ public:
   /// chosen arbitrarily.
   void setMatchAnyVertex() { matchOneVertex = false; }
 
-  /// Enable path traversal of registers.
-  void enableTraverseRegisters() { traverseRegisters = true; }
+  /// Enable or disable path traversal of registers.
+  void setTraverseRegisters(bool value) { traverseRegisters = value; }
 
-  /// Disable path traversal of registers.
-  void disableTraverseRegisters() { traverseRegisters = false; }
+  /// Set path start point restriction. When set to true, paths must start on
+  /// top-level ports or registers. When set to false, paths can start on any
+  /// variable.
+  void setRestrictStartPoints(bool value) { restrictStartPoints = value; }
+
+  /// Set path end point restriction. When set to true, paths must end on
+  /// top-level ports or registers. When set to false, paths can end on any
+  /// variable.
+  void setRestrictEndPoints(bool value) { restrictEndPoints = value; }
 
   /// Enable verbose output.
   void setVerbose() {
@@ -103,7 +111,9 @@ private:
       matchType(MatchType::EXACT),
       ignoreHierarchyMarkers(false),
       matchOneVertex(true),
-      traverseRegisters(false) {
+      traverseRegisters(false),
+      restrictStartPoints(true),
+      restrictEndPoints(true) {
     // Setup logging.
     boost::log::add_console_log(std::clog, boost::log::keywords::format = "%Severity%: %Message%");
     setQuiet();

--- a/lib/netlist_paths/Netlist.cpp
+++ b/lib/netlist_paths/Netlist.cpp
@@ -10,6 +10,7 @@ Netlist::Netlist(const std::string &filename) {
   ReadVerilatorXML(netlist, files, dtypes, filename);
   netlist.markAliasRegisters();
   netlist.splitRegVertices();
+  netlist.updateVarAliases();
 }
 
 std::vector<Vertex*>

--- a/lib/netlist_paths/Netlist.cpp
+++ b/lib/netlist_paths/Netlist.cpp
@@ -274,7 +274,7 @@ std::vector<std::vector<Vertex*> > Netlist::getAllPaths(Waypoints waypoints) con
 std::vector<std::vector<Vertex*> > Netlist::getAllFanOut(const std::string startName) const {
   auto vertex = getStartVertex(startName, Options::getInstance().isMatchAnyVertex());
   if (vertex == netlist.nullVertex()) {
-    throw Exception(std::string("could not find begin vertex "+startName));
+    throw Exception(std::string("could not find start vertex "+startName));
   }
   return createVertexPtrVecVec(netlist.getAllFanOut(vertex));
 }

--- a/lib/netlist_paths/python_wrapper.cpp
+++ b/lib/netlist_paths/python_wrapper.cpp
@@ -86,10 +86,10 @@ BOOST_PYTHON_MODULE(py_netlist_paths)
     .def("set_match_regex",               &Options::setMatchRegex)
     .def("set_match_any_vertex",          &Options::setMatchAnyVertex)
     .def("set_match_one_vertex",          &Options::setMatchOneVertex)
-    .def("enable_traverse_registers",     &Options::enableTraverseRegisters)
-    .def("disable_traverse_registers",    &Options::disableTraverseRegisters)
-    .def("set_ignore_hierarchy_markers",  &Options::setIgnoreHierarchyMarkers)
-    .def("set_respect_hierarchy_markers", &Options::setRespectHierarchyMarkers);
+    .def("set_traverse_registers",        &Options::setTraverseRegisters)
+    .def("set_restrict_start_points",     &Options::setRestrictStartPoints)
+    .def("set_restrict_end_points",       &Options::setRestrictEndPoints)
+    .def("set_ignore_hierarchy_markers",  &Options::setIgnoreHierarchyMarkers);
 
   int (RunVerilator::*run)(const std::string&, const std::string&) const = &RunVerilator::run;
 

--- a/tests/NameTests.cpp
+++ b/tests/NameTests.cpp
@@ -113,7 +113,7 @@ BOOST_FIXTURE_TEST_CASE(malformed_regex, TestContext) {
 /// counter
 BOOST_FIXTURE_TEST_CASE(hierarchy_separators_counter, TestContext) {
   BOOST_CHECK_NO_THROW(compile("counter.sv", "counter"));
-  netlist_paths::Options::getInstance().setIgnoreHierarchyMarkers();
+  netlist_paths::Options::getInstance().setIgnoreHierarchyMarkers(true);
 
   netlist_paths::Options::getInstance().setMatchRegex();
   BOOST_TEST(np->regExists("counter.counter_q")); // Heir dot
@@ -129,7 +129,7 @@ BOOST_FIXTURE_TEST_CASE(hierarchy_separators_counter, TestContext) {
 /// pipeline_module
 BOOST_FIXTURE_TEST_CASE(hierarchy_separators_pipeline_module, TestContext) {
   BOOST_CHECK_NO_THROW(compile("pipeline_module.sv", "pipeline_module"));
-  netlist_paths::Options::getInstance().setIgnoreHierarchyMarkers();
+  netlist_paths::Options::getInstance().setIgnoreHierarchyMarkers(true);
 
   netlist_paths::Options::getInstance().setMatchRegex();
   BOOST_TEST(np->regExists("pipeline_module.g_pipestage\\[0\\].u_pipestage.data_q")); // Hier dot

--- a/tests/PathTests.cpp
+++ b/tests/PathTests.cpp
@@ -572,7 +572,7 @@ BOOST_FIXTURE_TEST_CASE(paths_with_port_registers, TestContext) {
 
 BOOST_FIXTURE_TEST_CASE(through_registers, TestContext) {
   BOOST_CHECK_NO_THROW(compile("basic_ff_chain.sv"));
-  netlist_paths::Options::getInstance().enableTraverseRegisters();
+  netlist_paths::Options::getInstance().setTraverseRegisters(true);
   {
     // Any path: in -> a -> b -> out
     auto vertices = np->getAnyPath(netlist_paths::Waypoints("in", "out"));

--- a/tests/TestContext.hpp
+++ b/tests/TestContext.hpp
@@ -48,7 +48,7 @@ struct TestContext {
     qualifiedNames(topName);
     // Default options.
     netlist_paths::Options::getInstance().setMatchExact();
-    netlist_paths::Options::getInstance().setRespectHierarchyMarkers();
+    netlist_paths::Options::getInstance().setIgnoreHierarchyMarkers(false);
   }
 
   /// Compile a test and create a netlist object.

--- a/tests/py_wrapper_tests.py
+++ b/tests/py_wrapper_tests.py
@@ -19,7 +19,7 @@ class TestPyWrapper(unittest.TestCase):
         """
         comp = RunVerilator(defs.INSTALL_PREFIX)
         comp.run(os.path.join(defs.TEST_SRC_PREFIX, filename), 'netlist.xml')
-        Options.get_instance().set_respect_hierarchy_markers()
+        Options.get_instance().set_ignore_hierarchy_markers(False)
         Options.get_instance().set_match_exact()
         return Netlist('netlist.xml')
 

--- a/tests/py_wrapper_tests.py
+++ b/tests/py_wrapper_tests.py
@@ -145,7 +145,7 @@ class TestPyWrapper(unittest.TestCase):
         # Pipeline module
         np = self.compile_test('pipeline_module.sv')
         path = np.get_any_path(Waypoints('i_data', 'pipeline_module.g_pipestage[0].u_pipestage.data_q'))
-        self.assertTrue(len(path) == 7)
+        self.assertTrue(len(path) == 6)
 
     def test_path_all_any_to_any(self):
         """

--- a/tests/verilog/alias_start_point.sv
+++ b/tests/verilog/alias_start_point.sv
@@ -1,0 +1,21 @@
+module sub_module (
+  output logic out
+);
+  assign out = 1;
+endmodule
+
+module alias_start_point (
+  input logic i_clk
+);
+
+  logic x, y;
+  logic y_q;
+
+  sub_module u_a(x);
+
+  assign y = x;
+
+  always_ff @(posedge i_clk)
+    y_q <= y;
+
+endmodule

--- a/tests/verilog/aliases_sub_comb.sv
+++ b/tests/verilog/aliases_sub_comb.sv
@@ -1,0 +1,19 @@
+module sub_comb (
+  input  logic clk,
+  input  logic in,
+  output logic client_out,
+  input  logic client_in,
+  output logic out
+);
+  assign client_out = in;
+  assign out = client_in;
+endmodule
+
+module aliases_sub_comb (
+  input logic i_clk
+);
+  logic a__to__client_a, client_a__to__a, a__to__b;
+  logic b__to__client_b, client_b__to__b, b__to__a;
+  sub_comb u_a(.clk(i_clk), .in(b__to__a), .client_out(), .client_in(), .out(a__to__b));
+  sub_comb u_b(.clk(i_clk), .in(a__to__b), .client_out(), .client_in(), .out(b__to__a));
+endmodule

--- a/tests/verilog/aliases_sub_reg.sv
+++ b/tests/verilog/aliases_sub_reg.sv
@@ -1,0 +1,21 @@
+module sub_reg (
+  input  logic clk,
+  input  logic in,
+  output logic client_out,
+  input  logic client_in,
+  output logic out
+);
+  always_ff @(posedge clk) begin
+     client_out <= in;
+     out <= client_in;
+  end
+endmodule
+
+module aliases_sub_reg (
+  input logic i_clk
+);
+  logic a__to__client_a, client_a__to__a, a__to__b;
+  logic b__to__client_b, client_b__to__b, b__to__a;
+  sub_reg u_a(.clk(i_clk), .in(b__to__a), .client_out(), .client_in(), .out(a__to__b));
+  sub_reg u_b(.clk(i_clk), .in(a__to__b), .client_out(), .client_in(), .out(b__to__a));
+endmodule

--- a/tools/netlist_paths.py
+++ b/tools/netlist_paths.py
@@ -75,7 +75,7 @@ def dump_path_report(netlist, path, fd):
             index += 1
         # Statement only.
         else:
-            row = ('', '', path[index].get_ast_type_str(), '', path[index].get_location_str())
+            row = ('', '', '', path[index].get_ast_type_str(), path[index].get_location_str())
             index += 1
         rows.append(row)
     if len(rows) > 0:
@@ -166,6 +166,16 @@ def main():
                         const=lambda: Options.get_instance().enable_traverse_registers(),
                         default=lambda *args: None,
                         help='Allow paths to traverse registers')
+    parser.add_argument('--start-anywhere',
+                        action='store_const',
+                        const=lambda: Options.get_instance().set_restrict_start_points(False),
+                        default=lambda *args: None,
+                        help='Allow paths to start on any variable')
+    parser.add_argument('--end-anywhere',
+                        action='store_const',
+                        const=lambda: Options.get_instance().set_restrict_end_points(False),
+                        default=lambda *args: None,
+                        help='Allow paths to end on any variable')
     parser.add_argument('--all-paths',
                         action='store_true',
                         help='Find all paths between two points (exponential time)')
@@ -201,6 +211,8 @@ def main():
     args.regex()
     args.wildcard()
     args.ignore_hierarchy_markers()
+    args.start_anywhere()
+    args.end_anywhere()
     args.verbose()
     args.debug()
 

--- a/tools/netlist_paths.py
+++ b/tools/netlist_paths.py
@@ -78,7 +78,7 @@ def dump_path_report(netlist, path, fd):
             row = ('', '', '', path[index].get_ast_type_str(), path[index].get_location_str())
             index += 1
         rows.append(row)
-    if len(rows) > 0:
+    if len(rows) > 1:
         # Write the table out.
         write_table(rows, fd)
     else:
@@ -163,7 +163,7 @@ def main():
                         help='Specify a point for a path to avoid')
     parser.add_argument('--traverse-registers',
                         action='store_const',
-                        const=lambda: Options.get_instance().enable_traverse_registers(),
+                        const=lambda: Options.get_instance().set_traverse_registers(True),
                         default=lambda *args: None,
                         help='Allow paths to traverse registers')
     parser.add_argument('--start-anywhere',


### PR DESCRIPTION
- Allow paths to start and end on variables that are not combinatorial start and end points (top ports or registers).
- Allow paths to start on variable aliases by adding backwards edges from aliases.
- Add detection of a special case for paths between to aliases of the variable.
- Fix printing of 'no paths found' in `netlist_paths.py`.