### PR TITLE
Pass includes and defines from Python

### DIFF
--- a/include/netlist_paths/RunVerilator.hpp
+++ b/include/netlist_paths/RunVerilator.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <boost/filesystem.hpp>
+#include <boost/python.hpp>
 
 namespace fs = boost::filesystem;
 
@@ -35,6 +36,12 @@ public:
   int run(const std::vector<std::string> &includes,
           const std::vector<std::string> &defines,
           const std::vector<std::string> &inputFiles,
+          const std::string &outputFile) const;
+
+  // wrapper for calling from Python
+  int run(const boost::python::list &includes,
+          const boost::python::list &defines,
+          const boost::python::list &inputFiles,
           const std::string &outputFile) const;
 
   /// Run Verilator with a single source file and no other options.

--- a/lib/netlist_paths/RunVerilator.cpp
+++ b/lib/netlist_paths/RunVerilator.cpp
@@ -6,6 +6,7 @@
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/process.hpp>
+#include <boost/python.hpp>
 #include "netlist_paths/RunVerilator.hpp"
 #include "netlist_paths/Options.hpp"
 
@@ -52,6 +53,24 @@ int RunVerilator::run(const std::vector<std::string> &includes,
   }
   BOOST_LOG_TRIVIAL(info) << boost::format("Running %s %s") % verilatorExe % ss.str();
   return bp::system(verilatorExe, bp::args(args));
+}
+
+// A specialisation to be called in the Python wrapper
+int RunVerilator::run(const boost::python::list &_includes,
+                      const boost::python::list &_defines,
+                      const boost::python::list &_inputFiles,
+                      const std::string &outputFile) const {
+    std::vector<std::string> includes, defines, inputFiles;
+    for (int i = 0; i < len(_includes); i++) {
+        includes.push_back(boost::python::extract<std::string>(_includes[i]));
+    }
+    for (int i = 0; i < len(_defines); i++) {
+        defines.push_back(boost::python::extract<std::string>(_defines[i]));
+    }
+    for (int i = 0; i < len(_inputFiles); i++) {
+        inputFiles.push_back(boost::python::extract<std::string>(_inputFiles[i]));
+    }
+    return run(includes, defines, inputFiles, outputFile);
 }
 
 /// A specialistion of run used for testing.

--- a/lib/netlist_paths/python_wrapper.cpp
+++ b/lib/netlist_paths/python_wrapper.cpp
@@ -118,11 +118,13 @@ BOOST_PYTHON_MODULE(py_netlist_paths)
     .def("set_ignore_hierarchy_markers",  &Options::setIgnoreHierarchyMarkers)
     .def("set_error_on_unmatched_node",   &Options::setErrorOnUnmatchedNode);
 
-  int (RunVerilator::*run)(const std::string&, const std::string&) const = &RunVerilator::run;
-
+  int (RunVerilator::*run_short)(const std::string&, const std::string&) const = &RunVerilator::run;
+  int (RunVerilator::*run_long)(const boost::python::list&, const boost::python::list&,
+                                const boost::python::list&, const std::string&) const = &RunVerilator::run;
   class_<RunVerilator, boost::noncopyable>("RunVerilator",
                                            init<const std::string&>())
-    .def("run", run);
+     .def("run", run_short)
+     .def("run", run_long);
 
   class_<Waypoints>("Waypoints")
     .def(init<const std::string, const std::string>())

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -13,12 +13,12 @@ class TestPyWrapper(unittest.TestCase):
     def setUp(self):
         pass
 
-    def compile_test(self, filename):
+    def compile_test(self, filename, includes=[], defines=[]):
         """
         Compile a test and setup/reset options.
         """
         comp = RunVerilator(defs.INSTALL_PREFIX)
-        comp.run(os.path.join(defs.TEST_SRC_PREFIX, filename), 'netlist.xml')
+        comp.run(includes, defines, [os.path.join(defs.TEST_SRC_PREFIX, filename)], 'netlist.xml')
         Options.get_instance().set_error_on_unmatched_node(True)
         Options.get_instance().set_ignore_hierarchy_markers(False)
         Options.get_instance().set_match_exact()
@@ -208,6 +208,38 @@ class TestPyWrapper(unittest.TestCase):
       Options.get_instance().set_restrict_end_points(False)
       self.assertTrue(np.path_exists(Waypoints('aliases_sub_reg.u_a.out', 'aliases_sub_reg.u_b.in')))
       self.assertTrue(np.path_exists(Waypoints('aliases_sub_reg.u_a.out', 'aliases_sub_reg.u_b.client_out')))
+
+    def test_compile_single_include(self):
+      """
+      Test passing include paths to Verilator
+      """
+      np = self.compile_test('single_include.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a")])
+      path = np.get_any_path(Waypoints('data_i', 'data_o'))
+      self.assertTrue(not path.empty())
+
+    def test_compile_multiple_includes(self):
+      """
+      Test passing multiple include paths to Verilator
+      """
+      np = self.compile_test('multiple_includes.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a"), os.path.join(defs.TEST_SRC_PREFIX, "include_b")])
+      path = np.get_any_path(Waypoints('data_i', 'data_o'))
+      self.assertTrue(not path.empty())
+
+    def test_compile_single_define(self):
+      """
+      Test passing define to Verilator
+      """
+      np = self.compile_test('single_define.sv', defines = ['EXPR_A=data_i'])
+      path = np.get_any_path(Waypoints('data_i', 'data_o'))
+      self.assertTrue(not path.empty())
+
+    def test_compile_multiple_defines(self):
+      """
+      Test passing multiple defines, with and withput assignment to Verilator
+      """
+      np = self.compile_test('multiple_defines.sv', defines = ['MY_DEFINE', 'EXPR_A=data_i', 'EXPR_B=data_o', ])
+      path = np.get_any_path(Waypoints('data_i', 'data_o'))
+      self.assertTrue(not path.empty())
 
 
 if __name__ == '__main__':

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -192,54 +192,54 @@ class TestPyWrapper(unittest.TestCase):
         self.assertTrue(not path.empty())
 
     def test_through_registers(self):
-      """
-      Test enabling path traversal through registers.
-      """
-      np = self.compile_test('basic_ff_chain.sv')
-      Options.get_instance().set_traverse_registers(True)
-      self.assertTrue(np.path_exists(Waypoints('in', 'out')))
+        """
+        Test enabling path traversal through registers.
+        """
+        np = self.compile_test('basic_ff_chain.sv')
+        Options.get_instance().set_traverse_registers(True)
+        self.assertTrue(np.path_exists(Waypoints('in', 'out')))
 
     def test_restrict_start_end_points(self):
-      """
-      Test relaxation of path start/end point options.
-      """
-      np = self.compile_test('aliases_sub_reg.sv')
-      Options.get_instance().set_restrict_start_points(False)
-      Options.get_instance().set_restrict_end_points(False)
-      self.assertTrue(np.path_exists(Waypoints('aliases_sub_reg.u_a.out', 'aliases_sub_reg.u_b.in')))
-      self.assertTrue(np.path_exists(Waypoints('aliases_sub_reg.u_a.out', 'aliases_sub_reg.u_b.client_out')))
+        """
+        Test relaxation of path start/end point options.
+        """
+        np = self.compile_test('aliases_sub_reg.sv')
+        Options.get_instance().set_restrict_start_points(False)
+        Options.get_instance().set_restrict_end_points(False)
+        self.assertTrue(np.path_exists(Waypoints('aliases_sub_reg.u_a.out', 'aliases_sub_reg.u_b.in')))
+        self.assertTrue(np.path_exists(Waypoints('aliases_sub_reg.u_a.out', 'aliases_sub_reg.u_b.client_out')))
 
-    def test_compile_single_include(self):
-      """
-      Test passing include paths to Verilator
-      """
-      np = self.compile_test('single_include.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a")])
-      path = np.get_any_path(Waypoints('data_i', 'data_o'))
-      self.assertTrue(not path.empty())
+    def test_single_include(self):
+        """
+        Test passing include paths to Verilator
+        """
+        np = self.compile_test('single_include.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a")])
+        path = np.get_any_path(Waypoints('data_i', 'data_o'))
+        self.assertTrue(not path.empty())
 
-    def test_compile_multiple_includes(self):
-      """
-      Test passing multiple include paths to Verilator
-      """
-      np = self.compile_test('multiple_includes.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a"), os.path.join(defs.TEST_SRC_PREFIX, "include_b")])
-      path = np.get_any_path(Waypoints('data_i', 'data_o'))
-      self.assertTrue(not path.empty())
+    def test_multiple_includes(self):
+        """
+        Test passing multiple include paths to Verilator
+        """
+        np = self.compile_test('multiple_includes.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a"), os.path.join(defs.TEST_SRC_PREFIX, "include_b")])
+        path = np.get_any_path(Waypoints('data_i', 'data_o'))
+        self.assertTrue(not path.empty())
 
-    def test_compile_single_define(self):
-      """
-      Test passing define to Verilator
-      """
-      np = self.compile_test('single_define.sv', defines = ['EXPR_A=data_i'])
-      path = np.get_any_path(Waypoints('data_i', 'data_o'))
-      self.assertTrue(not path.empty())
+    def test_single_define(self):
+        """
+        Test passing define to Verilator
+        """
+        np = self.compile_test('single_define.sv', defines = ['EXPR_A=data_i'])
+        path = np.get_any_path(Waypoints('data_i', 'data_o'))
+        self.assertTrue(not path.empty())
 
-    def test_compile_multiple_defines(self):
-      """
-      Test passing multiple defines, with and withput assignment to Verilator
-      """
-      np = self.compile_test('multiple_defines.sv', defines = ['MY_DEFINE', 'EXPR_A=data_i', 'EXPR_B=data_o', ])
-      path = np.get_any_path(Waypoints('data_i', 'data_o'))
-      self.assertTrue(not path.empty())
+    def test_multiple_defines(self):
+        """
+        Test passing multiple defines, with and withput assignment to Verilator
+        """
+        np = self.compile_test('multiple_defines.sv', defines = ['MY_DEFINE', 'EXPR_A=data_i', 'EXPR_B=data_o', ])
+        path = np.get_any_path(Waypoints('data_i', 'data_o'))
+        self.assertTrue(not path.empty())
 
 
 if __name__ == '__main__':

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -211,7 +211,7 @@ class TestPyWrapper(unittest.TestCase):
 
     def test_single_include(self):
         """
-        Test passing include paths to Verilator
+        Test passing an include path to Verilator
         """
         np = self.compile_test('single_include.sv', includes = [os.path.join(defs.TEST_SRC_PREFIX, "include_a")])
         path = np.get_any_path(Waypoints('data_i', 'data_o'))
@@ -227,7 +227,7 @@ class TestPyWrapper(unittest.TestCase):
 
     def test_single_define(self):
         """
-        Test passing define to Verilator
+        Test passing a define to Verilator
         """
         np = self.compile_test('single_define.sv', defines = ['EXPR_A=data_i'])
         path = np.get_any_path(Waypoints('data_i', 'data_o'))

--- a/tests/integration/tool_tests.py
+++ b/tests/integration/tool_tests.py
@@ -99,6 +99,42 @@ class TestTool(unittest.TestCase):
         returncode, _ = self.run_np(['--compile', test_path, '--to', 'counter.counter_q'])
         self.assertEqual(returncode, 0)
 
+    def test_compile_single_include(self):
+        """
+        Test passing an include path to Verilator
+        """
+        test_path = os.path.join(defs.TEST_SRC_PREFIX, 'single_include.sv')
+        includes  = os.path.join(defs.TEST_SRC_PREFIX, "include_a")
+        returncode, _ = self.run_np(['--compile', test_path, '-I', includes])
+        self.assertEqual(returncode, 0)
+
+    def test_compile_multiple_includes(self):
+        """
+        Test passing multiple include paths to Verilator
+        """
+        test_path = os.path.join(defs.TEST_SRC_PREFIX, 'multiple_includes.sv')
+        includes  = [os.path.join(defs.TEST_SRC_PREFIX, "include_a"), os.path.join(defs.TEST_SRC_PREFIX, "include_b")]
+        returncode, _ = self.run_np(['--compile', test_path, '-I'] + includes)
+        self.assertEqual(returncode, 0)
+
+    def test_compile_single_define(self):
+        """
+        Test passing a define to Verilator
+        """
+        test_path = os.path.join(defs.TEST_SRC_PREFIX, 'single_define.sv')
+        defines   = 'EXPR_A=data_i'
+        returncode, _ = self.run_np(['--compile', test_path, '-D', defines])
+        self.assertEqual(returncode, 0)
+
+    def test_compile_multiple_defines(self):
+        """
+        Test passing multiple defines, with and withput assignment to Verilator
+        """
+        test_path = os.path.join(defs.TEST_SRC_PREFIX, 'multiple_defines.sv')
+        defines   = ['MY_DEFINE', 'EXPR_A=data_i', 'EXPR_B=data_o']
+        returncode, _ = self.run_np(['--compile', test_path, '-D'] + defines)
+        self.assertEqual(returncode, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/verilog/include_a/include_a.sv
+++ b/tests/verilog/include_a/include_a.sv
@@ -1,0 +1,8 @@
+module include_a(
+                 input  data_i,
+                 output data_o
+                 );
+
+   assign data_o = data_i;
+
+endmodule

--- a/tests/verilog/include_b/include_b.sv
+++ b/tests/verilog/include_b/include_b.sv
@@ -1,0 +1,9 @@
+module include_b(
+                 input [1:0] data_i,
+                 input       select_i,
+                 output      data_o
+                 );
+
+   assign data_o = (select_i == 1'b1) ? data_i[1] : data_i[0];
+
+endmodule

--- a/tests/verilog/multiple_defines.sv
+++ b/tests/verilog/multiple_defines.sv
@@ -1,0 +1,12 @@
+module multiple_defines(
+               input data_i,
+               output data_o
+               );
+   wire data_s;
+
+   assign data_s = `EXPR_A;
+   `ifdef MY_DEFINE
+       assign `EXPR_B = data_s;
+   `endif
+
+endmodule

--- a/tests/verilog/multiple_includes.sv
+++ b/tests/verilog/multiple_includes.sv
@@ -1,0 +1,21 @@
+`include "include_a.sv"
+`include "include_b.sv"
+
+module multiple_includes(
+               input data_i,
+               output data_o
+               );
+
+   wire data_s;
+
+   include_a i_include_a(
+                         .data_i(data_i),
+                         .data_o(data_s)
+                         );
+   include_b i_include_b(
+                         .data_i({data_i, data_s}),
+                         .select_i(1'b0),
+                         .data_o(data_o)
+                         );
+
+endmodule

--- a/tests/verilog/single_define.sv
+++ b/tests/verilog/single_define.sv
@@ -1,0 +1,8 @@
+module single_define(
+               input data_i,
+               output data_o
+               );
+
+   assign data_o = `EXPR_A;
+
+endmodule

--- a/tests/verilog/single_include.sv
+++ b/tests/verilog/single_include.sv
@@ -1,0 +1,12 @@
+`include "include_a.sv"
+
+module single_include(
+               input data_i,
+               output data_o
+               );
+
+   include_a i_include_a(
+                         .data_i(data_i),
+                         .data_o(data_o)
+                         );
+endmodule

--- a/tools/netlist_paths.py
+++ b/tools/netlist_paths.py
@@ -136,9 +136,13 @@ def main():
                         action='store_true',
                         help='Run Verilator to compile a netlist')
     parser.add_argument('-I',
+                        default=[],
+                        nargs='*',
                         metavar='include_path',
                         help='Add an source include path (only with --compile)')
     parser.add_argument('-D',
+                        default=[],
+                        nargs='*',
                         metavar='definition',
                         help='Define a preprocessor macro (only with --compile)')
     parser.add_argument('-o', '--output',
@@ -255,7 +259,6 @@ def main():
     args.debug()
 
     try:
-
         # Verilator compilation
         # (Only supports one source file currently, useful for testing.)
         if args.compile:
@@ -264,7 +267,7 @@ def main():
             else:
                 output_filename = args.output_file
             comp = RunVerilator(defs.INSTALL_PREFIX)
-            if comp.run(args.files[0], output_filename) > 0:
+            if comp.run(args.I, args.D, args.files, output_filename) > 0:
                 raise RuntimeError('error compiling design')
         else:
             if len(args.files) != 1:


### PR DESCRIPTION
Pass the previously unused Python command line arguments -I and -D to RunVerilator.
The conversion from boost::python::list seems a bit clumsy, but the best I could come up with for now.