### PR TITLE
test passing multiple files

### DIFF
--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -253,5 +253,9 @@ class TestPyWrapper(unittest.TestCase):
         path = np.get_any_path(Waypoints('data_i', 'data_o'))
         self.assertTrue(not path.empty())
 
+        np = self.compile_test(['include_a/include_a.sv', 'include_b/include_b.sv', 'multiple_files.sv'])
+        path = np.get_any_path(Waypoints('data_i', 'data_o'))
+        self.assertTrue(not path.empty())
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -13,12 +13,16 @@ class TestPyWrapper(unittest.TestCase):
     def setUp(self):
         pass
 
-    def compile_test(self, filename, includes=[], defines=[]):
+    def compile_test(self, files, includes=[], defines=[]):
         """
         Compile a test and setup/reset options.
         """
         comp = RunVerilator(defs.INSTALL_PREFIX)
-        comp.run(includes, defines, [os.path.join(defs.TEST_SRC_PREFIX, filename)], 'netlist.xml')
+        if type(files) is list:
+            _files = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), _file))
+        else:
+            _files = [os.path.join(defs.TEST_SRC_PREFIX, files)]
+        comp.run(includes, defines, _files, 'netlist.xml')
         Options.get_instance().set_error_on_unmatched_node(True)
         Options.get_instance().set_ignore_hierarchy_markers(False)
         Options.get_instance().set_match_exact()
@@ -240,7 +244,6 @@ class TestPyWrapper(unittest.TestCase):
         np = self.compile_test('multiple_defines.sv', defines = ['MY_DEFINE', 'EXPR_A=data_i', 'EXPR_B=data_o', ])
         path = np.get_any_path(Waypoints('data_i', 'data_o'))
         self.assertTrue(not path.empty())
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -19,7 +19,7 @@ class TestPyWrapper(unittest.TestCase):
         """
         comp = RunVerilator(defs.INSTALL_PREFIX)
         if type(files) is list:
-            _files = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), _file))
+            _files = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), files))
         else:
             _files = [os.path.join(defs.TEST_SRC_PREFIX, files)]
         comp.run(includes, defines, _files, 'netlist.xml')
@@ -242,6 +242,14 @@ class TestPyWrapper(unittest.TestCase):
         Test passing multiple defines, with and withput assignment to Verilator
         """
         np = self.compile_test('multiple_defines.sv', defines = ['MY_DEFINE', 'EXPR_A=data_i', 'EXPR_B=data_o', ])
+        path = np.get_any_path(Waypoints('data_i', 'data_o'))
+        self.assertTrue(not path.empty())
+
+    def test_multiple_files(self):
+        """
+        Test passing multiple files to compile with Verilator
+        """
+        np = self.compile_test(['multiple_files.sv', 'include_a/include_a.sv', 'include_b/include_b.sv'])
         path = np.get_any_path(Waypoints('data_i', 'data_o'))
         self.assertTrue(not path.empty())
 

--- a/tests/integration/tool_tests.py
+++ b/tests/integration/tool_tests.py
@@ -135,6 +135,15 @@ class TestTool(unittest.TestCase):
         returncode, _ = self.run_np(['--compile', test_path, '-D'] + defines)
         self.assertEqual(returncode, 0)
 
+    def test_compile_multiple_files(self):
+        """
+        Test passing multiple files to compile with Verilator
+        """
+        paths = ['multiple_files.sv', 'include_a/include_a.sv', 'include_b/include_b.sv']
+        full_paths = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), paths))
+        returncode, _ = self.run_np(['--compile'] + full_paths)
+        self.assertEqual(returncode, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/tool_tests.py
+++ b/tests/integration/tool_tests.py
@@ -144,6 +144,13 @@ class TestTool(unittest.TestCase):
         returncode, _ = self.run_np(['--compile'] + full_paths)
         self.assertEqual(returncode, 0)
 
+        # switch order, top-level not in first place
+        paths = ['include_a/include_a.sv', 'include_b/include_b.sv', 'multiple_files.sv']
+        full_paths = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), paths))
+        returncode, _ = self.run_np(['--compile'] + full_paths)
+        self.assertEqual(returncode, 0)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/verilog/multiple_files.sv
+++ b/tests/verilog/multiple_files.sv
@@ -1,0 +1,21 @@
+// this reuses the include files but not as actual includes,
+// but rather as additional files / modules to elaborate (like libraries)
+
+module multiple_files(
+               input data_i,
+               output data_o
+               );
+
+   wire data_s;
+
+   include_a i_include_a(
+                         .data_i(data_i),
+                         .data_o(data_s)
+                         );
+   include_b i_include_b(
+                         .data_i({data_i, data_s}),
+                         .select_i(1'b0),
+                         .data_o(data_o)
+                         );
+
+endmodule


### PR DESCRIPTION
I noticed that my previous changes from https://github.com/jameshanlon/netlist-paths/pull/24  also enable passing multiple files to compile.
This adds some basic tests for this feature, which I actually find quite useful when dealing with a netlist and cell libraries.