### PR TITLE
add --top-module option

### DIFF
--- a/include/netlist_paths/RunVerilator.hpp
+++ b/include/netlist_paths/RunVerilator.hpp
@@ -36,12 +36,14 @@ public:
   int run(const std::vector<std::string> &includes,
           const std::vector<std::string> &defines,
           const std::vector<std::string> &inputFiles,
+          const std::string &topModule,
           const std::string &outputFile) const;
 
   // wrapper for calling from Python
   int run(const boost::python::list &includes,
           const boost::python::list &defines,
           const boost::python::list &inputFiles,
+          const std::string &topModule,
           const std::string &outputFile) const;
 
   /// Run Verilator with a single source file and no other options.

--- a/lib/netlist_paths/RunVerilator.cpp
+++ b/lib/netlist_paths/RunVerilator.cpp
@@ -30,6 +30,7 @@ RunVerilator::RunVerilator(const std::string &binLocation) {
 int RunVerilator::run(const std::vector<std::string> &includes,
                       const std::vector<std::string> &defines,
                       const std::vector<std::string> &inputFiles,
+                      const std::string &topModule,
                       const std::string &outputFile) const {
   std::vector<std::string> args{"+1800-2012ext+.sv",
                                 "--bbox-sys",
@@ -38,6 +39,10 @@ int RunVerilator::run(const std::vector<std::string> &includes,
                                 "--flatten",
                                 "--error-limit", "10000",
                                 "--xml-output", outputFile};
+  if(!topModule.empty()) {
+      args.push_back("--top-module");
+      args.push_back(topModule);
+  }
   for (auto &path : includes) {
     args.push_back(std::string("+incdir+")+path);
   }
@@ -59,6 +64,7 @@ int RunVerilator::run(const std::vector<std::string> &includes,
 int RunVerilator::run(const boost::python::list &_includes,
                       const boost::python::list &_defines,
                       const boost::python::list &_inputFiles,
+                      const std::string &topModule,
                       const std::string &outputFile) const {
     std::vector<std::string> includes, defines, inputFiles;
     for (int i = 0; i < len(_includes); i++) {
@@ -70,11 +76,11 @@ int RunVerilator::run(const boost::python::list &_includes,
     for (int i = 0; i < len(_inputFiles); i++) {
         inputFiles.push_back(boost::python::extract<std::string>(_inputFiles[i]));
     }
-    return run(includes, defines, inputFiles, outputFile);
+    return run(includes, defines, inputFiles, topModule, outputFile);
 }
 
-/// A specialistion of run used for testing.
+// A specialistion of run used for testing.
 int RunVerilator::run(const std::string& inputFile, const std::string& outputFile) const {
   auto inputFiles = {inputFile};
-  return run({}, {}, inputFiles, outputFile);
+  return run({}, {}, inputFiles, "", outputFile);
 }

--- a/lib/netlist_paths/python_wrapper.cpp
+++ b/lib/netlist_paths/python_wrapper.cpp
@@ -120,7 +120,7 @@ BOOST_PYTHON_MODULE(py_netlist_paths)
 
   int (RunVerilator::*run_short)(const std::string&, const std::string&) const = &RunVerilator::run;
   int (RunVerilator::*run_long)(const boost::python::list&, const boost::python::list&,
-                                const boost::python::list&, const std::string&) const = &RunVerilator::run;
+                                const boost::python::list&, const std::string&, const std::string&) const = &RunVerilator::run;
   class_<RunVerilator, boost::noncopyable>("RunVerilator",
                                            init<const std::string&>())
      .def("run", run_short)

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -257,5 +257,19 @@ class TestPyWrapper(unittest.TestCase):
         path = np.get_any_path(Waypoints('data_i', 'data_o'))
         self.assertTrue(not path.empty())
 
+    def test_multiple_tops(self):
+        """
+        Test '--top-module' by passing multiple independent modules to Verilator
+        """
+
+        files = ['top_a.sv', 'top_b.sv']
+        np = self.compile_test(files, top_module='top_a')
+        path = np.get_any_path(Waypoints('data_a_i', 'data_a_o'))
+        self.assertTrue(not path.empty())
+
+        np = self.compile_test(files, top_module='top_b')
+        path = np.get_any_path(Waypoints('data_b_i', 'data_b_o'))
+        self.assertTrue(not path.empty())
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/py_wrapper_tests.py
+++ b/tests/integration/py_wrapper_tests.py
@@ -13,7 +13,7 @@ class TestPyWrapper(unittest.TestCase):
     def setUp(self):
         pass
 
-    def compile_test(self, files, includes=[], defines=[]):
+    def compile_test(self, files, includes=[], defines=[], top_module=""):
         """
         Compile a test and setup/reset options.
         """
@@ -22,7 +22,7 @@ class TestPyWrapper(unittest.TestCase):
             _files = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), files))
         else:
             _files = [os.path.join(defs.TEST_SRC_PREFIX, files)]
-        comp.run(includes, defines, _files, 'netlist.xml')
+        comp.run(includes, defines, _files, top_module, 'netlist.xml')
         Options.get_instance().set_error_on_unmatched_node(True)
         Options.get_instance().set_ignore_hierarchy_markers(False)
         Options.get_instance().set_match_exact()

--- a/tests/integration/tool_tests.py
+++ b/tests/integration/tool_tests.py
@@ -150,6 +150,24 @@ class TestTool(unittest.TestCase):
         returncode, _ = self.run_np(['--compile'] + full_paths)
         self.assertEqual(returncode, 0)
 
+    def test_multiple_tops(self):
+        """
+        Test '--top-module' by passing multiple independent modules to Verilator
+        """
+
+        # compilation fails without specifying top explicitly
+        paths = ['top_a.sv', 'top_b.sv']
+        full_paths = list(map(lambda p: os.path.join(defs.TEST_SRC_PREFIX, p), paths))
+        returncode, _ = self.run_np(['--compile'] + full_paths)
+        self.assertNotEqual(returncode, 0)
+
+        # compilation succeeds when specifying top
+        returncode, _ = self.run_np(['--compile'] + full_paths + ['--top-module', 'top_a'])
+        self.assertEqual(returncode, 0)
+
+        returncode, _ = self.run_np(['--compile'] + full_paths + ['--top-module', 'top_b'])
+        self.assertEqual(returncode, 0)
+
 
 
 if __name__ == '__main__':

--- a/tests/unit/TestContext.hpp
+++ b/tests/unit/TestContext.hpp
@@ -68,26 +68,27 @@ struct TestContext {
   }
 
   /// Compile a test and create a netlist object.
-  void compile(const std::string inFilename, std::string topName="") {
-    auto testPath = fs::path(testPrefix) / inFilename;
-    std::vector<std::string> includes = {};
-    std::vector<std::string> defines = {};
-    std::vector<std::string> inputFiles = {testPath.string()};
-    // Check the Verilator binary exists.
-    BOOST_ASSERT(boost::filesystem::exists(installPrefix));
-    netlist_paths::RunVerilator runVerilator(installPrefix);
-    auto outTemp = fs::unique_path();
-    runVerilator.run(includes,
-                     defines,
-                     inputFiles,
-                     outTemp.native());
-    np = std::make_unique<netlist_paths::Netlist>(outTemp.native());
-    fs::remove(outTemp);
-    if (topName.empty()) {
-      topName = boost::filesystem::change_extension(inFilename, "").string();
+    void compile(const std::string inFilename, std::string topName="", std::string topModule="") {
+        auto testPath = fs::path(testPrefix) / inFilename;
+        std::vector<std::string> includes = {};
+        std::vector<std::string> defines = {};
+        std::vector<std::string> inputFiles = {testPath.string()};
+        // Check the Verilator binary exists.
+        BOOST_ASSERT(boost::filesystem::exists(installPrefix));
+        netlist_paths::RunVerilator runVerilator(installPrefix);
+        auto outTemp = fs::unique_path();
+        runVerilator.run(includes,
+                         defines,
+                         inputFiles,
+                         topModule,
+                         outTemp.native());
+        np = std::make_unique<netlist_paths::Netlist>(outTemp.native());
+        fs::remove(outTemp);
+        if (topName.empty()) {
+            topName = boost::filesystem::change_extension(inFilename, "").string();
+        }
+        init(topName);
     }
-    init(topName);
-  }
 
   /// Create a netlist object from XML.
   void load(const std::string inFilename, std::string topName="") {

--- a/tests/verilog/top_a.sv
+++ b/tests/verilog/top_a.sv
@@ -1,0 +1,9 @@
+// test multiple independent top levels
+module top_a(
+             input  data_a_i,
+             output data_a_o
+             );
+
+   assign data_a_o = data_a_i;
+
+endmodule

--- a/tests/verilog/top_b.sv
+++ b/tests/verilog/top_b.sv
@@ -1,0 +1,9 @@
+// test multiple independent top levels
+module top_b(
+             input  data_b_i,
+             output data_b_o
+             );
+
+   assign data_b_o = data_b_i;
+
+endmodule

--- a/tools/netlist-paths/main.cpp
+++ b/tools/netlist-paths/main.cpp
@@ -22,6 +22,7 @@ int main(int argc, char **argv) {
     po::positional_options_description p;
     po::variables_map vm;
     std::vector<std::string> inputFiles;
+    std::string topModule;
     std::string outputFilename;
     std::string startName;
     std::string endName;
@@ -65,6 +66,10 @@ int main(int argc, char **argv) {
       ("match",         po::value<std::string>(&nameRegex)
                           ->value_name("name regex"),
                         "Regex to match names against (only with --dump-names)")
+      ("top,t",     po::value<std::string>(&topModule)
+                          ->default_value("")
+                          ->value_name("name"),
+                        "top module name")
       ("outfile,o",     po::value<std::string>(&outputFilename)
                           ->default_value(netlist_paths::DEFAULT_OUTPUT_FILENAME)
                           ->value_name("filename"),
@@ -119,6 +124,7 @@ int main(int argc, char **argv) {
       return compileGraph.run(includes,
                               defines,
                               inputFiles,
+                              topModule,
                               outputFilename);
     }
 

--- a/tools/netlist_paths.py
+++ b/tools/netlist_paths.py
@@ -145,6 +145,11 @@ def main():
                         nargs='*',
                         metavar='definition',
                         help='Define a preprocessor macro (only with --compile)')
+    parser.add_argument('-t', '--top-module',
+                        default="",
+                        dest='top_module',
+                        metavar='top module',
+                        help='Specify top module for compilation')
     parser.add_argument('-o', '--output',
                         default=None,
                         dest='output_file',
@@ -267,7 +272,7 @@ def main():
             else:
                 output_filename = args.output_file
             comp = RunVerilator(defs.INSTALL_PREFIX)
-            if comp.run(args.I, args.D, args.files, output_filename) > 0:
+            if comp.run(args.I, args.D, args.files, args.top_module, output_filename) > 0:
                 raise RuntimeError('error compiling design')
         else:
             if len(args.files) != 1:


### PR DESCRIPTION
When compiling multiple files there might be independent top levels (e.g. unused cells from a library). This exposes the Verilator `--top-module` option to choose the right one.

I guess there should be a more general `--extra-verliator-args `option to pass **any** other Verilator option (e.g. disable warnings, optimization, ...)